### PR TITLE
feat: add opt-in to allow people to use only python-package-managers-* buildpacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,35 @@
+# Copyright (c) 2013-Present CloudFoundry.org Foundation, Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
 /.bin
+/bin
 /build
+/linux/
 .idea/
-/linux
-/darwin
-/windows
 .DS_Store
+tmp.*/

--- a/detect.go
+++ b/detect.go
@@ -17,7 +17,14 @@ type BuildPlanMetadata struct {
 	// Launch flag requests the given requirement be made available during the
 	// launch phase of the buildpack lifecycle.
 	Launch bool `toml:"launch"`
+	Build  bool `toml:"build"`
 }
+
+const (
+	LiveReloadEnv            = "BP_LIVE_RELOAD_ENABLED"
+	PackageManagersEnv       = "BP_ENABLE_PACKAGE_MANAGERS"
+	PackageManagersPlanEntry = "package-managers-run"
+)
 
 // Detect will return a packit.DetectFunc that will be invoked during the
 // detect phase of the buildpack lifecycle.
@@ -186,6 +193,22 @@ func Detect() packit.DetectFunc {
 				})
 			}
 		}
+
+		shouldUsePackageManagers, err := checkShouldEnablePackageManagers()
+		if err != nil {
+			return packit.DetectResult{}, err
+		}
+		if shouldUsePackageManagers {
+			for i := range plans {
+				plans[i].Requires = append(plans[i].Requires, packit.BuildPlanRequirement{
+					Name: PackageManagersPlanEntry,
+					Metadata: BuildPlanMetadata{
+						Build: true,
+					},
+				})
+			}
+		}
+
 		return packit.DetectResult{
 			Plan: or(plans...),
 		}, nil
@@ -193,7 +216,7 @@ func Detect() packit.DetectFunc {
 }
 
 func checkLiveReloadEnabled() (bool, error) {
-	if reload, ok := os.LookupEnv("BP_LIVE_RELOAD_ENABLED"); ok {
+	if reload, ok := os.LookupEnv(LiveReloadEnv); ok {
 		shouldEnableReload, err := strconv.ParseBool(reload)
 		if err != nil {
 			return false, fmt.Errorf("failed to parse BP_LIVE_RELOAD_ENABLED value %s: %w", reload, err)
@@ -201,6 +224,19 @@ func checkLiveReloadEnabled() (bool, error) {
 		return shouldEnableReload, nil
 	}
 	return false, nil
+}
+
+func checkShouldEnablePackageManagers() (bool, error) {
+	shouldUsePackageManagers := false
+
+	if usePackageManagers, ok := os.LookupEnv(PackageManagersEnv); ok {
+		shouldUsePackageManagers, err := strconv.ParseBool(usePackageManagers)
+		if err != nil {
+			return false, fmt.Errorf("failed to parse %s value %s: %w", PackageManagersEnv, usePackageManagers, err)
+		}
+		return shouldUsePackageManagers, nil
+	}
+	return shouldUsePackageManagers, nil
 }
 
 func or(plans ...packit.BuildPlan) packit.BuildPlan {

--- a/detect_test.go
+++ b/detect_test.go
@@ -122,7 +122,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		context("with uv.lock file", func() {
 			it.Before(func() {
 				Expect(os.WriteFile(filepath.Join(workingDir, "uv.lock"), []byte{}, os.ModePerm)).To(Succeed())
-
 			})
 
 			it("detects", func() {
@@ -146,7 +145,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		context("when BP_LIVE_RELOAD_ENABLED=true in the build environment", func() {
 			it.Before(func() {
-				t.Setenv("BP_LIVE_RELOAD_ENABLED", "true")
+				t.Setenv(pythonstart.LiveReloadEnv, "true")
 			})
 
 			context("without uv.lock", func() {
@@ -295,6 +294,157 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 
+		context("when BP_ENABLE_PACKAGE_MANAGERS=true in the build environment", func() {
+			it.Before(func() {
+				t.Setenv(pythonstart.PackageManagersEnv, "true")
+			})
+
+			context("without uv.lock", func() {
+				it("requires watchexec at launch", func() {
+					result, err := detect(packit.DetectContext{
+						WorkingDir: workingDir,
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Plan).To(Equal(packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: "cpython",
+								Metadata: pythonstart.BuildPlanMetadata{
+									Launch: true,
+								},
+							},
+							{
+								Name: "site-packages",
+								Metadata: pythonstart.BuildPlanMetadata{
+									Launch: true,
+								},
+							},
+							{
+								Name: pythonstart.PackageManagersPlanEntry,
+								Metadata: pythonstart.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+						},
+						Or: []packit.BuildPlan{
+							{
+								Provides: []packit.BuildPlanProvision{},
+								Requires: []packit.BuildPlanRequirement{
+									{
+										Name: "conda-environment",
+										Metadata: pythonstart.BuildPlanMetadata{
+											Launch: true,
+										},
+									},
+									{
+										Name: pythonstart.PackageManagersPlanEntry,
+										Metadata: pythonstart.BuildPlanMetadata{
+											Build: true,
+										},
+									},
+								},
+							},
+							{
+								Provides: []packit.BuildPlanProvision{},
+								Requires: []packit.BuildPlanRequirement{
+									{
+										Name: "pixi-environment",
+										Metadata: pythonstart.BuildPlanMetadata{
+											Launch: true,
+										},
+									},
+									{
+										Name: pythonstart.PackageManagersPlanEntry,
+										Metadata: pythonstart.BuildPlanMetadata{
+											Build: true,
+										},
+									},
+								},
+							},
+							{
+								Provides: []packit.BuildPlanProvision{},
+								Requires: []packit.BuildPlanRequirement{
+									{
+										Name: "cpython",
+										Metadata: pythonstart.BuildPlanMetadata{
+											Launch: true,
+										},
+									},
+									{
+										Name: "poetry",
+										Metadata: pythonstart.BuildPlanMetadata{
+											Launch: true,
+										},
+									},
+									{
+										Name: "poetry-venv",
+										Metadata: pythonstart.BuildPlanMetadata{
+											Launch: true,
+										},
+									},
+									{
+										Name: pythonstart.PackageManagersPlanEntry,
+										Metadata: pythonstart.BuildPlanMetadata{
+											Build: true,
+										},
+									},
+								},
+							},
+							{
+								Provides: []packit.BuildPlanProvision{},
+								Requires: []packit.BuildPlanRequirement{
+									{
+										Name: "cpython",
+										Metadata: pythonstart.BuildPlanMetadata{
+											Launch: true,
+										},
+									},
+									{
+										Name: pythonstart.PackageManagersPlanEntry,
+										Metadata: pythonstart.BuildPlanMetadata{
+											Build: true,
+										},
+									},
+								},
+							},
+						},
+					}))
+				})
+			})
+
+			context("with uv.lock file", func() {
+				it.Before(func() {
+					Expect(os.WriteFile(filepath.Join(workingDir, "uv.lock"), []byte{}, os.ModePerm)).To(Succeed())
+
+				})
+
+				it("detects", func() {
+					result, err := detect(packit.DetectContext{
+						WorkingDir: workingDir,
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result.Plan).To(Equal(packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: "uv-environment",
+								Metadata: pythonstart.BuildPlanMetadata{
+									Launch: true,
+								},
+							},
+							{
+								Name: pythonstart.PackageManagersPlanEntry,
+								Metadata: pythonstart.BuildPlanMetadata{
+									Build: true,
+								},
+							},
+						},
+					}))
+				})
+			})
+		})
+
 		context("When only an environment.yml file is present", func() {
 			it.Before(func() {
 				Expect(os.RemoveAll(filepath.Join(workingDir, "x.py"))).To(Succeed())
@@ -396,13 +546,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	context("failure cases", func() {
 		context("when BP_LIVE_RELOAD_ENABLED is set to an invalid value", func() {
 			it.Before(func() {
-				err := os.Setenv("BP_LIVE_RELOAD_ENABLED", "not-a-bool")
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			it.After(func() {
-				err := os.Unsetenv("BP_LIVE_RELOAD_ENABLED")
-				Expect(err).NotTo(HaveOccurred())
+				t.Setenv(pythonstart.LiveReloadEnv, "not-a-bool")
 			})
 
 			it("returns an error", func() {
@@ -410,6 +554,19 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					WorkingDir: workingDir,
 				})
 				Expect(err).To(MatchError(ContainSubstring("failed to parse BP_LIVE_RELOAD_ENABLED value not-a-bool")))
+			})
+		})
+
+		context("when BP_ENABLE_PACKAGE_MANAGERS is set to an invalid value", func() {
+			it.Before(func() {
+				t.Setenv(pythonstart.PackageManagersEnv, "not-a-bool")
+			})
+
+			it("returns an error", func() {
+				_, err := detect(packit.DetectContext{
+					WorkingDir: workingDir,
+				})
+				Expect(err).To(MatchError(ContainSubstring("failed to parse BP_ENABLE_PACKAGE_MANAGERS value not-a-bool")))
 			})
 		})
 

--- a/integration.json
+++ b/integration.json
@@ -5,5 +5,8 @@
   ],
   "cpython": "index.docker.io/paketobuildpacks/cpython",
   "python-package-managers-install": "index.docker.io/paketobuildpacks/python-package-managers-install",
-  "python-package-managers-run": "index.docker.io/paketobuildpacks/python-package-managers-run"
+  "python-package-managers-run": "index.docker.io/paketobuildpacks/python-package-managers-run",
+
+  "miniconda": "index.docker.io/paketobuildpacks/miniconda",
+  "conda-env-update": "index.docker.io/paketobuildpacks/conda-env-update"
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -20,6 +20,9 @@ var (
 	pythonPackageManagersRunBuildpack     string
 	pythonPackageManagersInstallBuildpack string
 
+	minicondaBuildpack      string
+	condaEnvUpdateBuildpack string
+
 	buildpackInfo struct {
 		Buildpack struct {
 			ID   string
@@ -31,6 +34,9 @@ var (
 		Cpython                      string `json:"cpython"`
 		PythonPackageManagersInstall string `json:"python-package-managers-install"`
 		PythonPackageManagersRun     string `json:"python-package-managers-run"`
+
+		Miniconda      string `json:"miniconda"`
+		CondaEnvUpdate string `json:"conda-env-update"`
 	}
 )
 
@@ -72,9 +78,18 @@ func TestIntegration(t *testing.T) {
 		Execute(config.PythonPackageManagersRun)
 	Expect(err).NotTo(HaveOccurred())
 
+	minicondaBuildpack, err = buildpackStore.Get.
+		Execute(config.Miniconda)
+	Expect(err).NotTo(HaveOccurred())
+
+	condaEnvUpdateBuildpack, err = buildpackStore.Get.
+		Execute(config.CondaEnvUpdate)
+	Expect(err).NotTo(HaveOccurred())
+
 	SetDefaultEventuallyTimeout(30 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Default", testDefault)
+	suite("Use python-package-managers", testUsePythonPackageManager)
 	suite.Run(t)
 }

--- a/integration/use_package_managers_test.go
+++ b/integration/use_package_managers_test.go
@@ -1,0 +1,118 @@
+package integration_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testUsePythonPackageManager(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+		pack       occam.Pack
+		docker     occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when building a default app", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+			name      string
+			source    string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		context("successful", func() {
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+				Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			})
+			it("builds an oci image with conda-environment", func() {
+				var err error
+				source, err = sourceWithCode(filepath.Join("testdata", "conda_app"))
+				Expect(err).NotTo(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithPullPolicy("never").
+					WithBuildpacks(
+						pythonPackageManagersInstallBuildpack,
+						pythonPackageManagersRunBuildpack,
+						buildpack,
+					).
+					WithEnv(map[string]string{
+						"BP_ENABLE_PACKAGE_MANAGERS": "true",
+					}).
+					Execute(name, source)
+				Expect(err).NotTo(HaveOccurred(), logs.String())
+
+				Expect(logs).To(ContainLines(
+					MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
+					"  Assigning launch processes:",
+					"    web (default): python",
+				))
+
+				container, err = docker.Container.Run.
+					WithTTY().
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(
+					And(
+						MatchRegexp(`Python 3\.\d+\.\d+`),
+						ContainSubstring(`Type "help", "copyright", "credits" or "license" for more information.`),
+					),
+				)
+			})
+		})
+
+		context("error case", func() {
+			it("fails to build an oci image with conda-environment using old buildpacks", func() {
+				var err error
+				source, err = sourceWithCode(filepath.Join("testdata", "conda_app"))
+				Expect(err).NotTo(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithPullPolicy("never").
+					WithBuildpacks(
+						minicondaBuildpack,
+						condaEnvUpdateBuildpack,
+						buildpack,
+					).
+					WithEnv(map[string]string{
+						"BP_ENABLE_PACKAGE_MANAGERS": "true",
+					}).
+					Execute(name, source)
+				Expect(err).To(HaveOccurred(), logs.String())
+			})
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Add opt-in option to use python-package-managers-install/run in place of the classic set of package managers buildpacks.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This is part of the deprecation phase for the old buildpacks.
It gives Paketo users the option to test drive these two new buildpacks in their current pipeline using only an environment variable.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
